### PR TITLE
separating auth prefix into separate tag

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,1 @@
-module.exports.templateTags = [require('./src/access-token')];
+module.exports.templateTags = [require('./src/access-token'), require('./src/auth-prefix')];

--- a/src/access-token.js
+++ b/src/access-token.js
@@ -22,13 +22,12 @@ module.exports = {
     }
 
     const authenticationRequest = await context.util.models.request.getById(oauthRequestId);
-    const prefix = ((authenticationRequest || {}).authentication || {}).tokenPrefix;
 
     const token = await context.util.models.oAuth2Token.getByRequestId(authenticationRequest._id);
     const accessToken = (token || {}).accessToken || '';
 
     if (context.renderPurpose == null) {
-      return `${prefix} ${accessToken || "<access-token-pending>"}`.trim();
+      return (accessToken || "<access-token-pending>").trim();
     }
 
     if (!accessToken) {
@@ -42,6 +41,6 @@ module.exports = {
       return '';
     }
 
-    return `${prefix} ${accessToken}`.trim();
+    return accessToken.trim();
   }
 };

--- a/src/auth-prefix.js
+++ b/src/auth-prefix.js
@@ -1,0 +1,33 @@
+module.exports = {
+  name: 'prefix',
+  displayName: 'Auth Prefix',
+  description: "reference auth prefix from other requests",
+  args: [
+    {
+      displayName: 'Request',
+      type: 'model',
+      model: 'Request',
+    }
+  ],
+
+  async run(context, oauthRequestId) {
+    const { meta } = context;
+
+    if (!meta.requestId || !meta.workspaceId) {
+      return null;
+    }
+
+    if (!oauthRequestId) {
+      throw new Error('No request specified');
+    }
+
+    const authenticationRequest = await context.util.models.request.getById(oauthRequestId);
+    const prefix = ((authenticationRequest || {}).authentication || {}).tokenPrefix;
+
+    if (prefix === 'NO_PREFIX') {
+    	throw new Error('The selected request has specifically specified no prefix');
+    }
+
+    return `${prefix || 'Bearer'}`.trim();
+  }
+};


### PR DESCRIPTION
I moved the prefix to a new tag in order to match the use case, where they are used in separate fields (auth tag, bearer token option). The name for the new template tag is 'Auth Prefix', and will error with an appropriate message if 'NO_PREFIX' is used in the source request. Otherwise will default to 'Bearer' if no prefix is entered in the source request.